### PR TITLE
Fix typing in data classes

### DIFF
--- a/harvest/harvestdataclasses.py
+++ b/harvest/harvestdataclasses.py
@@ -499,6 +499,14 @@ class ProjectTaskAssignments:
     task: TaskRef = None
 
 @dataclass
+class ExternalRef:
+    id: str = None
+    group_id: str = None
+    permalink: str = None
+    service: str = None
+    service_icon_url: str = None
+
+@dataclass
 class TimeEntry:
     notes: Optional[str]
     locked_reason: Optional[str]
@@ -506,7 +514,7 @@ class TimeEntry:
     started_time: Optional[str]
     ended_time: Optional[str]
     invoice: Optional[InvoiceRef]
-    external_reference: Optional[str]
+    external_reference: Optional[ExternalRef]
     billable_rate: Optional[float]
     id: int = None
     spent_date: str = None
@@ -525,7 +533,7 @@ class TimeEntry:
     is_running: bool = None
     billable: bool = None
     budgeted: bool = None
-    cost_rate: float = None
+    cost_rate: Optional[float] = None
 
 
 @dataclass

--- a/tests/timesheets.py
+++ b/tests/timesheets.py
@@ -190,7 +190,13 @@ class TestTimesheets(unittest.TestCase):
                         "id":13150403,
                         "number":"1001"
                     },
-                "external_reference":None,
+                "external_reference":{
+                        "id":"31356723",
+                        "group_id":"Cyberdyne",
+                        "permalink":"https://isengard.net/merry/and/pippin",
+                        "service":"with_a_smile",
+                        "service_icon_url":"https://isengard.net/saruman.jpg"
+                    },
                 "billable":True,
                 "budgeted":True,
                 "billable_rate":100.0,
@@ -482,7 +488,7 @@ class TestTimesheets(unittest.TestCase):
                 "billable": True,
                 "budgeted": False,
                 "billable_rate": 100.00, # TODO: this is supposed to be an int. Something isn't casting int to float.
-                "cost_rate": 75.00 # TODO: this is supposed to be an int. Something isn't casting int to float.
+                "cost_rate": None
             }
 
         time_entries_dict = {


### PR DESCRIPTION
As per the V2 API docs, the external reference on a time entry is of type object.

https://help.getharvest.com/api-v2/timesheets-api/timesheets/time-entries/

Also, changes `cost_rate` to be an optional value as my current use case currently does not have `cost_rate` set.