### PR TITLE
Fix https://github.com/bradbase/python-harvest_apiv2/issues/17

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
-sudo: false
-matrix:
+jobs:
     include:
         - python: 3.7
           env: TOXENV=py37

--- a/harvest/harvest.py
+++ b/harvest/harvest.py
@@ -234,10 +234,11 @@ class Harvest(object):
 
     # invoice is a dataclass invoice
     def create_free_form_invoice(self, client_id, free_form_invoice):
-        return self.create_invoice(client_id, free_form_invoice)
+        free_form_invoice['client_id'] = client_id
+        return self.create_invoice(**free_form_invoice)
 
-    def create_invoice_based_on_tracked_time_and_expenses(self, client_id, invoice_import):
-        return self.create_free_form_invoice(client_id, invoice_import)
+    def create_invoice_based_on_tracked_time_and_expenses(self, client_id, invoice_import=InvoiceImport):
+        return self.create_free_form_invoice(client_id, asdict(invoice_import))
 
     # line_items is a list of LineItem
     def update_invoice(self, invoice_id, **kwargs):

--- a/harvest/harvest.py
+++ b/harvest/harvest.py
@@ -232,13 +232,11 @@ class Harvest(object):
         kwargs.update({'client_id': client_id})
         return from_dict(data_class=Invoice, data=self._post(url, data=kwargs))
 
-    # invoice is a dataclass invoice
-    def create_free_form_invoice(self, client_id, free_form_invoice):
-        free_form_invoice['client_id'] = client_id
-        return self.create_invoice(**free_form_invoice)
+    def create_free_form_invoice(self, client_id, **kwargs):
+        return self.create_invoice(client_id, **kwargs)
 
-    def create_invoice_based_on_tracked_time_and_expenses(self, client_id, invoice_import=InvoiceImport):
-        return self.create_free_form_invoice(client_id, asdict(invoice_import))
+    def create_invoice_based_on_tracked_time_and_expenses(self, client_id, **kwargs):
+        return self.create_invoice(client_id, **kwargs)
 
     # line_items is a list of LineItem
     def update_invoice(self, invoice_id, **kwargs):

--- a/harvest/harvest.py
+++ b/harvest/harvest.py
@@ -232,11 +232,17 @@ class Harvest(object):
         kwargs.update({'client_id': client_id})
         return from_dict(data_class=Invoice, data=self._post(url, data=kwargs))
 
-    def create_free_form_invoice(self, client_id, **kwargs):
-        return self.create_invoice(client_id, **kwargs)
+    def create_free_form_invoice(self, invoice : FreeFormInvoice):
+        invoice_dict = asdict(invoice)
+        client_id = invoice_dict['client_id']
+        invoice_dict.pop('client_id', None)
+        return self.create_invoice(client_id, **invoice_dict)
 
-    def create_invoice_based_on_tracked_time_and_expenses(self, client_id, **kwargs):
-        return self.create_invoice(client_id, **kwargs)
+    def create_invoice_based_on_tracked_time_and_expenses(self, invoice : InvoiceImport):
+        invoice_dict = asdict(invoice)
+        client_id = invoice_dict['client_id']
+        invoice_dict.pop('client_id', None)
+        return self.create_invoice(client_id, **invoice_dict)
 
     # line_items is a list of LineItem
     def update_invoice(self, invoice_id, **kwargs):

--- a/harvest/harvest.py
+++ b/harvest/harvest.py
@@ -239,7 +239,8 @@ class Harvest(object):
         return self.create_invoice(client_id, **invoice_dict)
 
     def create_invoice_based_on_tracked_time_and_expenses(self, invoice : InvoiceImport):
-        invoice_dict = asdict(invoice)
+        # translates from_date to from
+        invoice_dict = json.loads(invoice.to_json())
         client_id = invoice_dict['client_id']
         invoice_dict.pop('client_id', None)
         return self.create_invoice(client_id, **invoice_dict)

--- a/harvest/harvestdataclasses.py
+++ b/harvest/harvestdataclasses.py
@@ -209,16 +209,16 @@ class LineItem:
 
 @dataclass
 class ExpenseImport:
+    to: Optional[str]
+    attach_receipts: Optional[bool]
     summary_type: str
     #from: str = None
-    to: str = None
-    attach_receipt: str = None
 
 @dataclass
 class TimeImport:
+    to: Optional[str]
     summary_type: str
     #from: str = None
-    to: str = None
 
 @dataclass
 class LineItemImport:
@@ -315,19 +315,19 @@ class FreeFormInvoice:
 class InvoiceImport:
     notes: Optional[str]
     line_items_import: Optional[LineItemImport]
+    subject: Optional[str]
+    retainer_id: Optional[int]
+    estimate_id: Optional[int]
+    number: Optional[str]
+    purchase_order: Optional[str]
+    tax: Optional[float]
+    tax2: Optional[float]
+    discount: Optional[float]
+    currency: Optional[str]
+    issue_date: Optional[str]
+    due_date: Optional[str]
+    payment_term: Optional[str]
     client_id: int
-    retainer_id: int = None
-    estimate_id: int = None
-    number: str = None
-    purchase_order: str = None
-    tax: float = None
-    tax2: float = None
-    discount: float = None
-    subject: str = None
-    currency: str = None
-    issue_date: str = None
-    due_date: str = None
-    payment_term: str = None
 
 @dataclass
 class ClientContact:

--- a/harvest/harvestdataclasses.py
+++ b/harvest/harvestdataclasses.py
@@ -3,6 +3,7 @@
 
 from dataclasses import dataclass, field
 from typing import Optional, List
+from dataclasses_json import config, dataclass_json
 
 @dataclass
 class Auth:
@@ -207,18 +208,22 @@ class LineItem:
     taxed: bool = None
     taxed2: bool = None
 
+#https://stackoverflow.com/questions/60074344/reserved-word-as-an-attribute-name-in-a-dataclass-when-parsing-a-json-object
+@dataclass_json
 @dataclass
 class ExpenseImport:
     to: Optional[str]
     attach_receipts: Optional[bool]
+    from_date: Optional[str] = field(metadata=config(field_name="from"))
     summary_type: str
-    #from: str = None
 
+#https://stackoverflow.com/questions/60074344/reserved-word-as-an-attribute-name-in-a-dataclass-when-parsing-a-json-object
+@dataclass_json
 @dataclass
 class TimeImport:
     to: Optional[str]
+    from_date: Optional[str] = field(metadata=config(field_name="from"))
     summary_type: str
-    #from: str = None
 
 @dataclass
 class LineItemImport:
@@ -311,6 +316,7 @@ class FreeFormInvoice:
     line_items: Optional[List[LineItem]]
     client_id: int
 
+@dataclass_json
 @dataclass
 class InvoiceImport:
     notes: Optional[str]

--- a/harvest/harvestdataclasses.py
+++ b/harvest/harvestdataclasses.py
@@ -296,20 +296,20 @@ class Invoice:
 @dataclass
 class FreeFormInvoice:
     notes: Optional[str]
+    retainer_id: Optional[int]
+    estimate_id: Optional[int]
+    number: Optional[str]
+    purchase_order: Optional[str]
+    tax: Optional[float]
+    tax2: Optional[float]
+    discount: Optional[float]
+    subject: Optional[str]
+    currency: Optional[str]
+    issue_date: Optional[str]
+    due_date: Optional[str]
+    payment_term: Optional[str]
+    line_items: Optional[List[LineItem]]
     client_id: int
-    retainer_id: int = None
-    estimate_id: int = None
-    number: str = None
-    purchase_order: str = None
-    tax: float = None
-    tax2: float = None
-    discount: float = None
-    subject: str = None
-    currency: str = None
-    issue_date: str = None
-    due_date: str = None
-    payment_term: str = None
-    line_items: List[LineItem] = None
 
 @dataclass
 class InvoiceImport:

--- a/harvest/harvestdataclasses.py
+++ b/harvest/harvestdataclasses.py
@@ -168,7 +168,7 @@ class UserAssignment:
     hourly_rate: float = None
 
 @dataclass
-class Project:
+class ProjectRef:
     code: Optional[str]
     id: int = None
     name: str = None
@@ -179,7 +179,7 @@ class Expense:
     user: Optional[User]
     receipt: Optional[Receipt]
     invoice: Optional[InvoiceRef]
-    project: Optional[Project]
+    project: Optional[ProjectRef]
     notes: Optional[str]
     id: int = None
     total_cost: float = None
@@ -197,7 +197,7 @@ class Expense:
 
 @dataclass
 class LineItem:
-    project: Optional[Project]
+    project: Optional[ProjectRef]
     id: int = None
     kind: str = None
     description: str = None
@@ -224,7 +224,7 @@ class TimeImport:
 class LineItemImport:
     time: Optional[TimeImport]
     expenses: Optional[ExpenseImport]
-    project_ids: List[Project]
+    project_ids: List[int]
 
 @dataclass
 class Creator:
@@ -461,7 +461,7 @@ class TaskAssignment:
     is_active: bool = None
     created_at: str = None
     updated_at: str = None
-    project: Project = None
+    project: ProjectRef = None
     task: TaskAssignmentRef = None
 
 @dataclass
@@ -473,7 +473,7 @@ class UserAssignment:
     is_active: bool = None
     created_at: str = None
     updated_at: str = None
-    project: Project = None
+    project: ProjectRef = None
     user: User = None
 
 @dataclass
@@ -509,7 +509,7 @@ class TimeEntry:
     spent_date: str = None
     user: User = None
     client: Client = None
-    project: Project = None
+    project: ProjectRef = None
     task: Task = None
     user_assignment: UserAssignment = None
     task_assignment: ProjectTaskAssignments = None

--- a/harvest/metadata.py
+++ b/harvest/metadata.py
@@ -1,7 +1,7 @@
 
 # Copyright 2020 Bradbase
 
-__version__ = "1.9.0"
+__version__ = "1.11.0"
 __author__ = "Bradley van Ree"
 __copyright__ = "Copyright 2020 Bradbase"
 __maintainer__ = "Bradley van Ree"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ requests-oauthlib
 dacite
 configparser
 httpretty
+dataclasses_json

--- a/tests/test_invoices.py
+++ b/tests/test_invoices.py
@@ -692,6 +692,27 @@ class TestInvoices(unittest.TestCase):
         requested_invoice = self.harvest.get_invoice(invoice_id= 13150378)
         self.assertEqual(requested_invoice, invoice)
 
+        #create_free_form_invoice
+        httpretty.register_uri(httpretty.POST,
+                "https://api.harvestapp.com/api/v2/invoices",
+                body=json.dumps(invoice_13150453_dict),
+                status=200
+            )
+        created_invoice = from_dict(data_class=Invoice, data=invoice_13150453_dict)
+        requested_created_invoice = self.harvest.create_free_form_invoice(client_id= 5735774, subject= "ABC Project Quote", due_date= "2017-07-27", line_items= [{"kind" : "Service", "description" : "ABC Project", "unit_price" : 5000.0}])
+        self.assertEqual(requested_created_invoice, created_invoice)
+
+        #create_invoice_based_on_tracked_time_and_expenses
+        httpretty.register_uri(httpretty.POST,
+                "https://api.harvestapp.com/api/v2/invoices",
+                body=json.dumps(invoice_13150453_dict),
+                status=200
+            )
+        created_invoice = from_dict(data_class=Invoice, data=invoice_13150453_dict)
+        invoice_to_create = {"subject":"ABC Project Quote","payment_term":"upon receipt","line_items_import":{"project_ids":[14307913],"time":{"summary_type":"task","from":"2017-03-01","to":"2017-03-31"},"expenses":{"summary_type":"category"}}}
+        requested_created_invoice = self.harvest.create_invoice_based_on_tracked_time_and_expenses(client_id= 5735774, **invoice_to_create)
+        self.assertEqual(requested_created_invoice, created_invoice)
+
         # create_invoice
         httpretty.register_uri(httpretty.POST,
                 "https://api.harvestapp.com/api/v2/invoices",
@@ -750,6 +771,7 @@ class TestInvoices(unittest.TestCase):
         updated_invoice = from_dict(data_class=Invoice, data=invoice_13150453_dict)
         requested_updated_invoice = self.harvest.update_invoice_line_item(invoice_id= 13150453, line_item = {"id":53341928,"description":"ABC Project Phase 2","unit_price":5000.0})
         self.assertEqual(requested_created_invoice, created_invoice)
+
 
         # delete_invoice_line_items
         del(invoice_13150453_dict['line_items'][1])

--- a/tests/test_invoices.py
+++ b/tests/test_invoices.py
@@ -699,7 +699,8 @@ class TestInvoices(unittest.TestCase):
                 status=200
             )
         created_invoice = from_dict(data_class=Invoice, data=invoice_13150453_dict)
-        requested_created_invoice = self.harvest.create_free_form_invoice(client_id= 5735774, subject= "ABC Project Quote", due_date= "2017-07-27", line_items= [{"kind" : "Service", "description" : "ABC Project", "unit_price" : 5000.0}])
+        free_form_invoice = from_dict(data_class=FreeFormInvoice, data={"client_id":5735774,"subject":"ABC Project Quote","due_date":"2017-07-27","line_items":[{"kind":"Service","description":"ABC Project","unit_price":5000.0}]})
+        requested_created_invoice = self.harvest.create_free_form_invoice(free_form_invoice)
         self.assertEqual(requested_created_invoice, created_invoice)
 
         #create_invoice_based_on_tracked_time_and_expenses
@@ -709,8 +710,8 @@ class TestInvoices(unittest.TestCase):
                 status=200
             )
         created_invoice = from_dict(data_class=Invoice, data=invoice_13150453_dict)
-        invoice_to_create = {"subject":"ABC Project Quote","payment_term":"upon receipt","line_items_import":{"project_ids":[14307913],"time":{"summary_type":"task","from":"2017-03-01","to":"2017-03-31"},"expenses":{"summary_type":"category"}}}
-        requested_created_invoice = self.harvest.create_invoice_based_on_tracked_time_and_expenses(client_id= 5735774, **invoice_to_create)
+        import_invoice = from_dict(data_class=InvoiceImport, data={"client_id":5735774, "subject":"ABC Project Quote","payment_term":"upon receipt","line_items_import":{"project_ids":[14307913],"time":{"summary_type":"task","from":"2017-03-01","to":"2017-03-31"},"expenses":{"summary_type":"category"}}})
+        requested_created_invoice = self.harvest.create_invoice_based_on_tracked_time_and_expenses(import_invoice)
         self.assertEqual(requested_created_invoice, created_invoice)
 
         # create_invoice

--- a/tox.ini
+++ b/tox.ini
@@ -15,4 +15,4 @@ pip_pre = True
 
 commands =
     # NOTE: you can run any command line tool here - not just tests
-    py.test -rw -s --tb=native --cov=harvest --cov-report=term-missing tests/
+    python -m pytest -rw -s --tb=native --cov=harvest --cov-report=term-missing tests/{posargs}


### PR DESCRIPTION
Fix duplicate `class Project`:
- rename first one to `ProjectRef`
- change dataclasses that included `Project` to use `ProjectRef` instead
  if they were aligned with APIs that only required id, name, and code.py
Change `List[Project]` in `LineItemImport` to `List[int]` to align with what API expects
Fix helper methods than invoke `create_invoice`
- `too many position arguments` error with `create_free_form_invoice` calling `create_invoice`
- duplicate `client_id` assignment due to InvoiceImport including a client_id but client_id also being a parameter
- add `InvoiceImport` type hint to `create_invoice_based_on_tracked_time_and_expenses` then convert to dict

All (pre-existing) tests pass