### PR TITLE
Add support for custom timeframe

### DIFF
--- a/harvest/detailedreports.py
+++ b/harvest/detailedreports.py
@@ -126,7 +126,7 @@ class DetailedReports(Harvest):
             raise ValueError(
                 "unknown argument \'timeframe\': \'%s\'" % timeframe_upper)
 
-        return {'from_date': start_date, 'to_date': end_date}
+        return {'from': start_date, 'to': end_date}
 
 
     # team is user

--- a/harvest/detailedreports.py
+++ b/harvest/detailedreports.py
@@ -112,9 +112,15 @@ class DetailedReports(Harvest):
         elif timeframe_upper == 'ALL TIME':
             return {}
 
-        # Not currently supported
-        elif timeframe_upper == 'CUSTOM':
-            raise ValueError("Custom timeframe not currently supported.")
+        # Custom timeframe format:
+        # start and end dates (yyyy-mm-dd) separated with ','
+        elif ',' in timeframe_upper:
+            try:
+                start_date = timeframe_upper.split(',')[0]
+                end_date = timeframe_upper.split(',')[1]
+            except:
+                raise ValueError(
+                    "unknown argument \'timeframe\': \'%s\'" % timeframe_upper)
 
         else:
             raise ValueError(


### PR DESCRIPTION
Hello @bradbase,
 Here is finally my proposal to handle custom timeframes. I've been using it for months, and it works ok.
I also included in this pull request a fix for dates attributes ('from_date' and 'to_date' were used instead of 'from' and 'to').
Thanks,
Patrick.